### PR TITLE
CI: Use OVMF image with included variable store

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -34,8 +34,8 @@ QEMU_BASEARGS=(
 	-chardev null,id=serial,logfile=/dev/stdout,logappend=on -serial chardev:serial -monitor none
 	-virtfs "local,path=${tmpdir},mount_tag=tmpdir,security_model=none")
 
-if [ -e /usr/share/qemu/ovmf-x86_64-code.bin ]; then
-	QEMU_BASEARGS+=(-bios /usr/share/qemu/ovmf-x86_64-code.bin)
+if [ -e /usr/share/qemu/ovmf-x86_64.bin ]; then
+	QEMU_BASEARGS+=(-bios /usr/share/qemu/ovmf-x86_64.bin)
 elif [ -e /usr/share/qemu/OVMF.fd ]; then
 	QEMU_BASEARGS+=(-bios /usr/share/qemu/OVMF.fd)
 else


### PR DESCRIPTION
Newer OVMF fails to start with an assert failure otherwise:

NvVarStore FV headers were invalid.
ASSERT /home/abuild/rpmbuild/BUILD/edk2/OvmfPkg/Library/PlatformInitLib/Platform.c(932): ((BOOLEAN)(0==1))